### PR TITLE
Add missing typings for xmpp.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.5",
+    "@types/xmpp__jid": "^0.6.1",
+    "@types/xmpp__xml": "^0.6.0",
     "tslint": "^5.20.0",
     "typescript": "^3.6.3"
   }

--- a/src/types/client-core.d.ts
+++ b/src/types/client-core.d.ts
@@ -1,0 +1,13 @@
+declare module '@xmpp/client-core' {
+    import { Connection } from '@xmpp/connection'
+
+    export class Client extends Connection {
+        /**
+         * Sends a stanza.
+         * @param stanza Stanza (xml element) to send.
+         * @returns Promise that resolves once the stanza is serialized
+         * and written to the socket or rejects if any of those fails.
+         */
+        send(stanza: Element): Promise<void>
+    }
+}

--- a/src/types/client.d.ts
+++ b/src/types/client.d.ts
@@ -1,0 +1,52 @@
+declare module '@xmpp/client' {
+    import { Client } from '@xmpp/client-core'
+    import { Reconnect } from '@xmpp/reconnect'
+    import * as jid from '@xmpp/jid'
+    import * as xml from '@xmpp/xml'
+
+    export interface XmppOptions {
+        /**
+         * The service to connect to, accepts an URI or a domain.
+         *  - `domain` lookup and connect to the most secure endpoint using @xmpp/resolve
+         *  - `xmpp://hostname:port` plain TCP, may be upgraded to TLS by @xmpp/starttls
+         *  - `xmpps://hostname:port` direct TLS
+         *  - `ws://hostname:port/path` plain WebSocket
+         *  - `wss://hostname:port/path` secure WebSocket
+         */
+        service: string
+        /**
+         * Optional domain of the service, if omitted will use the hostname from {@link XmppOptions#service}.
+         * Useful when the service domain is different than the service hostname.
+         */
+        domain?: string
+        /**
+         * Optional resource for resource binding.
+         */
+        resource?: string
+        /**
+         * Optional username for sasl.
+         */
+        username?: string
+        /**
+         * Optional password for sasl.
+         */
+        password?: string
+    }
+
+    interface Xmpp {
+        /**
+         * @see {@link https://github.com/xmppjs/xmpp.js/blob/HEAD/packages/reconnect}
+         */
+        reconnect: Reconnect
+    }
+
+    type xmpp = Client & Xmpp
+
+    /**
+     * Creates instance of xmpp client.
+     * @param options Connection options.
+     */
+    export function client(options: XmppOptions): xmpp
+
+    export { jid, xml }
+}

--- a/src/types/connection.d.ts
+++ b/src/types/connection.d.ts
@@ -1,0 +1,87 @@
+declare module '@xmpp/connection' {
+    import { EventEmitter } from 'events'
+    import { JID } from '@xmpp/jid'
+    import { Element } from '@xmpp/xml'
+
+    type ConnectionStatus =
+        'online'
+        | 'offline'
+        | 'connecting'
+        | 'opening'
+        | 'open'
+        | 'closing'
+        | 'close'
+        | 'disconnecting'
+        | 'disconnect'
+
+    export class Connection extends EventEmitter {
+        /**
+         * `online` indicates that `xmpp` is authenticated and addressable.
+         * It is emitted every time there is a successful (re)connection.
+         *
+         * `offline` indicates that `xmpp` disconnected and no automatic attempt
+         * to reconnect will happen (after calling `xmpp.stop()`).
+         *
+         * Additional status:
+         *  - `connecting`: Socket is connecting
+         *  - `connect`: Socket is connected
+         *  - `opening`: Stream is opening
+         *  - `open`: Stream is open
+         *  - `closing`: Stream is closing
+         *  - `close`: Stream is closed
+         *  - `disconnecting`: Socket is disconnecting
+         *  - `disconnect`: Socket is disconnected
+         *
+         * You can listen for status change using the `status` event.
+         */
+        status: ConnectionStatus
+
+        /**
+         * Emitted when the status changes.
+         * @param event Event name.
+         * @param listener Event listener.
+         */
+        on(event: 'status', listener: (status: ConnectionStatus) => void): this
+        /**
+         * Emitted when an error occurs.
+         * For connection errors, xmpp will reconnect on its own using `@xmpp/reconnect`
+         * however a listener MUST be attached to avoid uncaught exceptions.
+         * @param event Event name.
+         * @param listener Event listener.
+         */
+        on(event: 'error', listener: (error: Error) => void): this
+        /**
+         * Emitted when a stanza is received and parsed.
+         * @param event Event name.
+         * @param listener Event listener.
+         */
+        on(event: 'stanza', listener: (stanza: Element) => void): this
+        /**
+         * Emitted when connected, authenticated and ready to receive/send stanzas.
+         * @param event Event name.
+         * @param listener Event listener.
+         */
+        on(event: 'online', listener: (jid: JID) => void): void
+        /**
+         * Emitted when the connection is closed an no further attempt to reconnect
+         * will happen, after calling `xmpp.stop()`.
+         * @param event Event name.
+         * @param listener Event listener.
+         */
+        on(event: 'offline', listener: () => void): void
+
+        /**
+         * Starts the connection. Attempts to reconnect will automatically happen
+         * if it cannot connect or gets disconnected.
+         * @returns Promise that resolves if the first attempt succeed
+         * or rejects if the first attempt fails.
+         */
+        start(): Promise<void>
+        /**
+         * Stops the connection and prevent any further auto reconnect/retry.
+         * @returns Promise that resolves once the stream closes
+         * and the socket disconnects.
+         */
+        stop(): Promise<void>
+    }
+}

--- a/src/types/reconnect.d.ts
+++ b/src/types/reconnect.d.ts
@@ -1,0 +1,32 @@
+declare module '@xmpp/reconnect' {
+    import { EventEmitter } from 'events'
+
+    export class Reconnect extends EventEmitter {
+        /**
+         * Property to set/get the delay in milliseconds between connection
+         * closed and reconnecting.
+         *
+         * Default is `1000`.
+         */
+        delay: number
+
+        /**
+         * Emitted each time a re-connection is attempted.
+         * @param event Event name.
+         * @param listener Event listener.
+         */
+        on(event: 'reconnecting', listener: () => void): this
+        /**
+         * Emitted each time a re-connection succeed.
+         * @param event Event name.
+         * @param listener Event listener.
+         */
+        on(event: 'reconnected', listener: () => void): this
+        /**
+         * Emitted on entity each time a re-connection fails.
+         * @param event Event name.
+         * @param listener Event listener.
+         */
+        on(event: 'error', listener: (err: Error) => void): this
+    }
+}


### PR DESCRIPTION
Without typings we can't use it in TypeScript.

There are already typings for @xmpp/jid and @xmpp/xml, but no typings
for @xmpp/client and it's dependencies.